### PR TITLE
luacheck

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,14 @@
+-- ignore line length warnings
+max_line_length=false
+max_code_line_length=false
+max_string_line_length=false
+max_comment_line_length=false
+-- show the warning/error codes as well
+codes=true
+-- don't show files with no issues
+quiet=1
+-- don't show undefined variable usage
+-- there are thousands of warnings here because luacheck is unaware of Wesnoth's lua environment and has no way to check which have been loaded
+global=false
+-- don't show unused variables
+unused=false

--- a/lua/domination.lua
+++ b/lua/domination.lua
@@ -99,5 +99,4 @@ function wesnoth.wml_actions.dethrall_units(cfg)
 		end
 	end
 end
-	
-	
+

--- a/lua/wlp.lua
+++ b/lua/wlp.lua
@@ -82,7 +82,7 @@ function wesnoth.wml_actions.highlight_image(cfg)
 	local bg = cfg.background or ""
 	local where = wesnoth.map.find(cfg)[1]
 	if not where then return end
-	
+
 	wesnoth.interface.scroll_to_hex(where, false, false, true)
 	if cfg.outline then
 		wesnoth.interface.highlight_hex(where)


### PR DESCRIPTION
This PR basically just sets up the lua code for being checked with luacheck; after the whitespace fixes here, the only remaining luacheck warnings are:
```
$ luacheck-5.3 .
Checking lua/ca_envoy_attack.lua                  1 warning

    lua/ca_envoy_attack.lua:28:23: (W421) shadowing definition of variable enemy on line 20

Checking lua/potions.lua                          2 warnings

    lua/potions.lua:12:7: (W411) variable haste_total was previously defined on line 4
    lua/potions.lua:13:7: (W411) variable healing_total was previously defined on line 5

Checking lua/wlp.lua                              1 warning

    lua/wlp.lua:40:9: (W421) shadowing definition of variable index on line 22

Total: 4 warnings / 0 errors in 11 files
```
